### PR TITLE
Move entrypoint to exec style

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ RUN adduser -Ds /bin/bash cachelink && chown -R cachelink:cachelink /cachelink
 USER cachelink
 
 EXPOSE 3111
-ENTRYPOINT ./bin/cachelink
+ENTRYPOINT ["./bin/cachelink"]


### PR DESCRIPTION
Move the entrypoint to exec style from shell style (https://docs.docker.com/engine/reference/builder/#entrypoint)